### PR TITLE
Fix HunterOfHunters Passive

### DIFF
--- a/Public/DnD2024_897914ef-5c96-053c-44af-0be823f895fe/Stats/Generated/Data/Passive.txt
+++ b/Public/DnD2024_897914ef-5c96-053c-44af-0be823f895fe/Stats/Generated/Data/Passive.txt
@@ -916,7 +916,7 @@ data "PriorityOrder" "9"
 data "Properties" "Highlighted;ForceShowInCC"
 data "Boosts" "ActionResource(ChannelDivinity,1,0);UnlockSpell(Shout_TurnUndead);"
 
-new entry "HunterofHunters"
+new entry "HunterOfHunters"
 type "PassiveData"
 data "DisplayName" "hc221e310gd9ccg02f1g44b5gac522e4fb680;1"
 data "Description" "hc185c90bg2db6g5709gea36g5211048efe69;2"
@@ -7908,4 +7908,5 @@ data "Properties" "Highlighted;OncePerTurn"
 data "StatsFunctorContext" "OnCast"
 data "Conditions" "IsSpellSchool(SpellSchool.Divination);"
 data "StatsFunctors" "IF(SpellPowerLevelEqualTo(6)):RestoreResource(SELF,SpellSlot,1,4);IF(SpellPowerLevelEqualTo(5)):RestoreResource(SELF,SpellSlot,1,4);IF(SpellPowerLevelEqualTo(4)):RestoreResource(SELF,SpellSlot,1,3);IF(SpellPowerLevelEqualTo(3)):RestoreResource(SELF,SpellSlot,1,2);IF(SpellPowerLevelEqualTo(2)):RestoreResource(SELF,SpellSlot,1,1);"
+
 


### PR DESCRIPTION
Case sensitivity typo on the data entry for HunterOfHunters passive was preventing it from being applied for HunterOfHunters feat, as well as Night Stalker background.